### PR TITLE
Add email and role claims to JWT token generation

### DIFF
--- a/src/main/java/com/userService/service/Jwt/JwtService.java
+++ b/src/main/java/com/userService/service/Jwt/JwtService.java
@@ -22,6 +22,9 @@ public class JwtService {
     }
 
     private String getToken(HashMap<String,Object> extraClaims, Users user) {
+        extraClaims.put("email", user.getEmail());
+        extraClaims.put("role", user.getRole().getRole_name());
+
         return Jwts
                 .builder()
                 .setClaims(extraClaims)


### PR DESCRIPTION
Updated the `getToken` method to include user email and role as additional claims in the JWT payload. This enhances token functionality by embedding important user details for downstream services.